### PR TITLE
use hapi-shutdown to unannounce on SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #Hapi-service-discovery
 [![Build Status](https://travis-ci.org/opentable/hapi-service-discovery.png?branch=master)](https://travis-ci.org/opentable/hapi-service-discovery) [![NPM version](https://badge.fury.io/js/hapi-service-discovery.png)](http://badge.fury.io/js/hapi-service-discovery) ![Dependencies](https://david-dm.org/opentable/hapi-service-discovery.png)
 
-Hapi Plugin for opentable-flavoured service-discovery 
+Hapi Plugin for opentable-flavoured service-discovery
 
 Connects the discovery client, exposes routes for announce, unannounce (so that you can control the server externally), and wraps the logging to server.log
 
@@ -22,11 +22,13 @@ server.pack.register({
     discoveryRoutesAuth: false, // optional, default behaviour is to inherit the route default, can either be false (to disable auth) or the name of an auth strategy (to override the route default).
     metadata: { // metadata is optional
       domain: 'com'
-    }, 
+    },
     onError: function(err) {
       // optional error handler
       // when set, forces initialisation to continue when any runtime errors are encountered
-    }
+    },
+    gracefulShutdown: true, // uses hapi-shutdown to unannounce gracefully on SIGTERM (defaults to false)
+    waitOnShutdown: 20 * 1000 // time to wait after unannounce (defaults to 30 seconds)
 });
 
 server.start(function(){

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 var service = require('./lib/service'),
     joi = require('joi'),
     schema = require('./lib/schema'),
+    routes = require('./lib/routes'),
     config = {};
 
-exports.register = function(plugin, options, next){
+exports.register = function(server, options, next){
   config = options;
   var validation = joi.validate(options, schema)
 
@@ -13,67 +14,10 @@ exports.register = function(plugin, options, next){
     return next(err);
   }
 
-  plugin.log(["discovery"], "registering discovery routes");
-  plugin.route([
-    {
-      method: "GET",
-      path: "/discovery/announce",
-      config: {
-        auth: options.discoveryRoutesAuth,
-        handler: function(request, reply){
-          service.announce(function(err){
-            if(err){
-                return reply(err);
-            }
+  server.log(["discovery"], "registering discovery routes");
+  server.route(routes(config));
 
-            reply();
-          });
-        }
-      }
-    },
-    {
-      method: "GET",
-      path: "/discovery/unannounce",
-      config: {
-        auth: options.discoveryRoutesAuth,
-        handler: function(request, reply){
-          service.unannounce(function(err){
-            if(err){
-              return reply(err);
-            }
-            reply();
-          });
-        }
-      }
-    },
-    {
-      method: "GET",
-      path: "/discovery/lease",
-      config: {
-        auth: options.discoveryRoutesAuth,
-        handler: function(request, reply){
-          var lease = service.lease();
-          if(!lease){
-            return reply().code(404);
-          }
-
-          reply(lease);
-        }
-      }
-    },
-    {
-      method: "GET",
-      path: "/discovery/lastUpdate",
-      config: {
-        auth: options.discoveryRoutesAuth,
-        handler: function(request, reply){
-          reply({ lastUpdate: service.lastUpdate().toISOString() });
-        }
-      }
-    }
-  ]);
-
-  plugin.expose({
+  server.expose({
     announce: service.announce,
     unannounce: service.unannounce,
     find: service.find,

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ exports.register = function(server, options, next){
 
   if(config.gracefulShutdown){
     server.dependency('hapi-shutdown', function(_, done){
-      server.plugins['hapi-shutdown'].register({
+      var err = server.plugins['hapi-shutdown'].register({
         taskname: 'discovery-unannounce',
         task: function(){
           service.unannounce(function(){});
@@ -35,7 +35,7 @@ exports.register = function(server, options, next){
         timeout: config.waitOnShutdown || 30 * 1000
       });
 
-      done();
+      done(err);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,22 @@ exports.register = function(server, options, next){
     findAll: service.findAll
   });
 
-  service.init(plugin, config, function(){
+  if(config.gracefulShutdown){
+    server.dependency('hapi-shutdown', function(_, done){
+      server.plugins['hapi-shutdown'].register({
+        taskname: 'discovery-unannounce',
+        task: function(){
+          service.unannounce(function(){});
+          // don't call done because we need to wait for the timeout
+        },
+        timeout: config.waitOnShutdown || 30 * 1000
+      });
+
+      done();
+    });
+  }
+
+  service.init(server, config, function(){
     next();
   });
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,0 +1,62 @@
+var service = require("./service");
+
+module.exports = function(options){
+  return [
+    {
+      method: "GET",
+      path: "/discovery/announce",
+      config: {
+        auth: options.discoveryRoutesAuth,
+        handler: function(request, reply){
+          service.announce(function(err){
+            if(err){
+                return reply(err);
+            }
+
+            reply();
+          });
+        }
+      }
+    },
+    {
+      method: "GET",
+      path: "/discovery/unannounce",
+      config: {
+        auth: options.discoveryRoutesAuth,
+        handler: function(request, reply){
+          service.unannounce(function(err){
+            if(err){
+              return reply(err);
+            }
+            reply();
+          });
+        }
+      }
+    },
+    {
+      method: "GET",
+      path: "/discovery/lease",
+      config: {
+        auth: options.discoveryRoutesAuth,
+        handler: function(request, reply){
+          var lease = service.lease();
+          if(!lease){
+            return reply().code(404);
+          }
+
+          reply(lease);
+        }
+      }
+    },
+    {
+      method: "GET",
+      path: "/discovery/lastUpdate",
+      config: {
+        auth: options.discoveryRoutesAuth,
+        handler: function(request, reply){
+          reply({ lastUpdate: service.lastUpdate().toISOString() });
+        }
+      }
+    }
+  ];
+};

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -5,5 +5,7 @@ module.exports = {
   serviceType: joi.string().min(1).required(),
   metadata: joi.object(),
   serviceUri: joi.string().regex(/http(s)?:\/\/[A-Za-z0-9-\/+]+/i),
-  onError: joi.func()
+  onError: joi.func(),
+  gracefulShutdown: joi.boolean(),
+  waitOnShutdown: joi.number().integer()
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-mocha-test": "^0.11.0",
+    "hoek": "^2.11.0",
     "proxyquire": "^1.0.1",
     "should": "^4.3.0"
   }


### PR DESCRIPTION
```
{
  gracefulShutdown: true,
  waitOnShutdown: 30 * 1000
}
```

Optionally unannounce on SIGTERM, then wait for the specified period (milliseconds).

Uses hapi-shutdown to add a SIGTERM trigger, when gracefulShutdown is enabled it adds a runtime dependency on hapi-shutdown using `server.dependency(...)`

This means that if we run `sudo service locationApi stop` then it will unannounce and shutdown gracefully before exiting. Similarly when rebooting the machine.